### PR TITLE
requests: ensure headers are not empty

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -43,10 +43,14 @@ export async function headerBuilder(header: object) {
 	const headers = new Headers()
 
 	for (const key in default_const.header) {
-		headers.append(key, default_const.header[key])
+		if (default_const.header[key]) {
+			headers.append(key, default_const.header[key])
+		}
 	}
 	for (const key in header) {
-		headers.append(key, header[key])
+		if (header[key]) {
+			headers.append(key, header[key])
+		}
 	}
 
 	headers.append('X-Goog-Visitor-Id', await getVisitorId())


### PR DESCRIPTION
This fix some issues with React Native, where the request couldn't be done due to invalid headers